### PR TITLE
Fix SW tests by defining global __WB_MANIFEST

### DIFF
--- a/src/utils/__tests__/swMessageHandler.test.ts
+++ b/src/utils/__tests__/swMessageHandler.test.ts
@@ -19,6 +19,7 @@ beforeEach(async () => {
   } as any;
 
   // Workbox expects this manifest to be defined during tests
+  (global as any).__WB_MANIFEST = [];
   (global as any).self.__WB_MANIFEST = [];
 
   (global as any).caches = {


### PR DESCRIPTION
## Summary
- ensure `__WB_MANIFEST` is defined on `global` before importing service worker

## Testing
- `npx vitest run`