### PR TITLE
Fix SW interval cleanup

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -50,10 +50,10 @@ self.addEventListener('activate', (event) => {
   const cleanup = () => {
     if (self.__versionCheckInterval) {
       clearInterval(self.__versionCheckInterval);
-      delete self.__versionCheckInterval;
     }
   };
 
+  // Listen for controllerchange/statechange to detect replacement
   self.addEventListener('controllerchange', cleanup);
   self.addEventListener('statechange', cleanup);
 });


### PR DESCRIPTION
## Summary
- ensure sw.js clears version check interval when replaced

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npm run test`